### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/edinc/java-selenium-framework/security/code-scanning/1](https://github.com/edinc/java-selenium-framework/security/code-scanning/1)

The optimal solution is to add a `permissions` block at the appropriate level in the workflow YAML file.  Since there is only one job defined (`test`), you can add the `permissions` block either at the root (applies to all jobs) or directly under the `test` job. The standard minimal starting point is to set `permissions: contents: read`, which allows the workflow to read repository contents but not modify them. If future actions require additional permissions, those can be added as necessary with more granular privileges. This change should be made in `.github/workflows/ci.yml`, immediately after the workflow `name:` and before `on:` (for root) or just below the `runs-on:` line (for job-level permissions).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
